### PR TITLE
Update gemspec to use add_runtime_dependency instead of requirements

### DIFF
--- a/crystalscad.gemspec
+++ b/crystalscad.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 	
 	gem.required_ruby_version = ">= 1.9.3"
-	gem.requirements	<< "rubyscad"
-	gem.requirements	<< "require_all"
+	gem.add_runtime_dependency "rubyscad", ">= 1.0"
+	gem.add_runtime_dependency "require_all", ">= 1.3"
 	
 end
 


### PR DESCRIPTION
Requirements in gemspecs are [just textual notes](http://guides.rubygems.org/specification-reference/#requirements) and do not indicate a gem dependency. This change means that a `gem install crystalscad` will install its dependencies out of the box.
