### PR TITLE
removed method_missing because it hides coding errors

### DIFF
--- a/lib/crystalscad/CrystalScadObject.rb
+++ b/lib/crystalscad/CrystalScadObject.rb
@@ -40,9 +40,5 @@ module CrystalScad
       file.puts scad_output
       file.close		
 		end
-
-		def method_missing(meth, *args, &block)		
-		end
-	
 	end
 end


### PR DESCRIPTION
Hello,

I'm trying CrystalSCAD in my hobby project and it looks promising. Thank you!
And I experienced an issue while writing CrystalSCAD code so that I created this PR.

When I write like this:
```ruby
polygon(points: some_points).linear_extrude(height: @vessel_support_span).center_z
```
ruby does not show error, but center_z is not available. So method_missing is called and it resulted in a missing 3d object.

I think it's better to show the error like usual and let me know that there's an error.

Please let me know if there's some considerations about this behavior.
