### PR TITLE
Allow text to accept numeric attributes

### DIFF
--- a/examples/text.rb
+++ b/examples/text.rb
@@ -1,0 +1,11 @@
+#!/usr/bin/ruby1.9.3
+require "rubygems"
+require "crystalscad"
+include CrystalScad
+
+string = "CrystalScad!"
+
+res = text(text: string)
+res += text(text: string, size: 3).translate(y: 10)
+res += text(text: string, spacing: 0.75).translate(y: 20)
+res.save("text.scad")

--- a/lib/crystalscad/CrystalScad.rb
+++ b/lib/crystalscad/CrystalScad.rb
@@ -256,8 +256,28 @@ module CrystalScad
   class AdvancedPrimitive < Primitive
     
     
+		NUMERIC_ATTRIBUTES = []
+
+    def self.numeric_attributes(*attribute_names)
+			Array(attribute_names).flatten.each do |attrbute_name|
+				NUMERIC_ATTRIBUTES << attrbute_name.to_sym
+			end
+		end
+
+		class <<self
+			alias_method :numeric_attribute, :numeric_attributes
+		end
+
     def initialize(attributes)
-      @attr = attributes.collect { |k, v| "#{k} = \"#{v}\"" }.join(', ')
+			@attr = attributes.collect { |k, v|
+				value_output = if NUMERIC_ATTRIBUTES.include?(k.to_sym)
+					v.to_f
+				else
+					"\"#{v}\""
+				end
+
+				"#{k} = #{value_output}"
+			}.join(', ')
       super
     end
     
@@ -269,6 +289,7 @@ module CrystalScad
 
 
   class Text < AdvancedPrimitive
+		numeric_attributes :size, :spacing
 		def initialize(attributes)
 			@operation = "text"
 			super(attributes)


### PR DESCRIPTION
The PR allows a Text object to accept `size` and `spacing` attributes.

OpenScad expects them to be numeric but, previously, they would be cast to strings and ignored. This adds a way to define certain attributes of an AdvancedPrimitive as numeric, and to cast them to  a Float.

I hope the way numeric attributes are set (using the `numeric_attributes` class method) will be useful in the future on other classes.

It also adds an example to show how to use the Text class and use the `size` and `spacing` attributes.